### PR TITLE
Fix frozen object issues.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,7 @@
     StylusCompiler.prototype._dependencyRegExp = /^ *@import ['"](.*)['"]/;
 
     function StylusCompiler(config) {
-      var _base, _base1, _ref1, _ref2,
+      var _ref1, _ref2,
         _this = this;
       this.config = config;
       this.getDependencies = __bind(this.getDependencies, this);
@@ -37,16 +37,12 @@
 
       this.compile = __bind(this.compile, this);
 
-      if ((_base = this.config).plugins == null) {
-        _base.plugins = {};
-      }
       if (this.config.stylus) {
         console.warn("Warning: config.stylus is deprecated, move it to config.plugins.stylus");
-        if ((_base1 = this.config.plugins).stylus == null) {
-          _base1.stylus = this.config.stylus;
-        }
+        this.cfg = this.config.stylus;
+      } else {
+        this.cfg = ((_ref1 = this.config.plugins) != null ? _ref1.stylus : void 0) != null ? this.config.plugins.stylus : {};
       }
-      this.cfg = (_ref1 = this.config.plugins.stylus) != null ? _ref1 : {};
       if (this.cfg.spriting) {
         this.iconPath = (_ref2 = this.cfg.iconPath) != null ? _ref2 : sysPath.join('images', 'icons');
         this.iconPathFull = sysPath.join(this.config.paths.assets, this.iconPath);

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -12,12 +12,11 @@ module.exports = class StylusCompiler
   _dependencyRegExp: /^ *@import ['"](.*)['"]/
 
   constructor: (@config) ->
-    @config.plugins ?= {}
     if @config.stylus
       console.warn "Warning: config.stylus is deprecated, move it to config.plugins.stylus"
-      @config.plugins.stylus ?= @config.stylus
-
-    @cfg = @config.plugins.stylus ? {}
+      @cfg = @config.stylus
+    else
+      @cfg = if @config.plugins?.stylus? then @config.plugins.stylus else {}
 
     if @cfg.spriting
       @iconPath = @cfg.iconPath ? sysPath.join 'images', 'icons'


### PR DESCRIPTION
This is the error I get now when I try to run `brunch watch` with the stylus-brunch plugin:

```
TypeError: Cannot read property 'stylus' of undefined
    at new StylusCompiler (/node_modules/stylus-brunch/lib/index.js:44:44)
    at /usr/local/lib/node_modules/brunch/lib/helpers.js:500:14
    at Array.map (native)
    at Object.exports.getPlugins (/usr/local/lib/node_modules/brunch/lib/helpers.js:499:8)
    at /usr/local/lib/node_modules/brunch/lib/watch.js:175:25
    at Object.exports.loadPackages (/usr/local/lib/node_modules/brunch/lib/helpers.js:493:12)
    at initialize (/usr/local/lib/node_modules/brunch/lib/watch.js:167:20)
    at new BrunchWatcher (/usr/local/lib/node_modules/brunch/lib/watch.js:254:7)
    at module.exports.watch (/usr/local/lib/node_modules/brunch/lib/watch.js:292:12)
    at ArgumentParser.parse (/usr/local/lib/node_modules/brunch/node_modules/argumentum/lib/argumentum.js:407:27)
    at Object.exports.run (/usr/local/lib/node_modules/brunch/lib/cli.js:100:47)
    at Object.<anonymous> (/usr/local/lib/node_modules/brunch/bin/brunch:7:32)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:901:3
```

This is happening because of the following:

1) I don't have a 'plugin' key on my config object.
2) The config object is frozen.

So, to fix this, I removed instances where the config object was modified.
